### PR TITLE
Make title/book-control vertical overlap adjustable

### DIFF
--- a/app/shared/src/commonMain/kotlin/org/gnit/bible/app/AppUi.kt
+++ b/app/shared/src/commonMain/kotlin/org/gnit/bible/app/AppUi.kt
@@ -9,3 +9,10 @@ const val SPACE_BETWEEN_BUTTON_WITH_SLIDER = 1
 const val BUTTON_ROUND = 5
 const val BUTTON_TEXT_FONT_SIZE = 15
 const val BUTTON_CONTENT_PADDING = 0
+
+/**
+ * This value is either 0 or positive integer. When the value is 0, the title and
+ * book control stick together. When the value is positive, the title goes down
+ * vertically and overwraps with book control by that integer value in dp.
+ */
+const val TITLE_BOOK_CONTROL_VERTICAL_OVERWRAP_DELTA: Int = 0

--- a/app/shared/src/commonMain/kotlin/org/gnit/bible/app/screens/TopBar.kt
+++ b/app/shared/src/commonMain/kotlin/org/gnit/bible/app/screens/TopBar.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.absolutePadding
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -125,6 +126,8 @@ fun TopBarContent(
         } else {
             bibleState.mainTranslation.language.sansFontFamily()
         }
+        val titleBookControlVerticalOffset =
+            TITLE_BOOK_CONTROL_VERTICAL_OVERWRAP_DELTA.coerceAtLeast(0).dp
 
         Row(
             modifier = Modifier
@@ -141,6 +144,7 @@ fun TopBarContent(
             Box(
                 modifier = Modifier
                     .padding(top = max(min(bibleState.fontSize, 10), 5).dp)
+                    .offset(y = titleBookControlVerticalOffset)
                     .weight(1f),
                 contentAlignment = Alignment.Center
             ) {


### PR DESCRIPTION
## Summary

- Added `TITLE_BOOK_CONTROL_VERTICAL_OVERWRAP_DELTA` as an app UI constant, defaulting to `0`.
- Applied the value to the title container with `Modifier.offset(y = ...)`, so a positive value moves the title downward without increasing the measured top-bar height.
- Clamped the applied value to `0` or greater to preserve the intended non-negative-only behavior.

## Impact

This lets local development builds tune the visual balance between the title and book control. Setting the constant to a positive integer allows the title descender space to visually overlap the book control area by that many dp.

The adjustment is implemented in shared `TopBarContent`, so it applies to both the normal chrome-visible path and the auto-hide/full-screen path whenever the top chrome is visible.

## Validation

- Inspected the relevant Compose top-bar and book-control code paths.
- Did not run a local Gradle build because this change was made through the GitHub connector rather than a local checkout.